### PR TITLE
Don't inline routes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,16 +86,17 @@ resource "aws_route_table" "route_table_private" {
   count  = "${var.availability_zones_count}"
   vpc_id = "${aws_vpc.vpc.id}"
 
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = "${element(aws_nat_gateway.nat.*.id, count.index)}"
-  }
-
   tags {
     Environment = "${var.environment}"
     Name        = "${format("%s-PrivateRT-AZ%d", var.name, count.index +1)}"
     Provisioner = "rackspace"
   }
+}
+
+resource "aws_route" "default_private_route" {
+  route_table_id         = "${element(aws_route_table.route_table_private.*.id, count.index)}"
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = "${element(aws_nat_gateway.nat.*.id, count.index)}"
 }
 
 ### Private Subnet Route Table Associations
@@ -110,16 +111,17 @@ resource "aws_route_table_association" "private_subnet_assocation" {
 resource "aws_route_table" "route_table_public" {
   vpc_id = "${aws_vpc.vpc.id}"
 
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.internet.id}"
-  }
-
   tags {
     Environment = "${var.environment}"
     Name        = "${format("%s-PublicRT", var.name)}"
     Provisioner = "rackspace"
   }
+}
+
+resource "aws_route" "default_public_route" {
+  route_table_id         = "${element(aws_route_table.route_table_public.*.id, count.index)}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = "${element(aws_internet_gateway.internet.*.id, count.index)}"
 }
 
 ### Public Route Table Associations


### PR DESCRIPTION
Move inline `aws_route` outside of `aws_route_table`. Mixing inline and non-inline route table entries is not supported by Terraform, and will result in overwriting resources. Since downstream consumers will likely use `aws_route` resources, we should move all of our routes to use those too.

See [this note](https://www.terraform.io/docs/providers/aws/r/route_table.html):
> NOTE on Route Tables and Routes: Terraform currently provides both a standalone Route resource and a Route Table resource with routes defined in-line. At this time you cannot use a Route Table with in-line routes in conjunction with any Route resources. Doing so will cause a conflict of rule settings and will overwrite rules.