### PR TITLE
Adding an additional output for the VPN Gateways

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -23,3 +23,8 @@ output "private_route_table_ids" {
   description = "List of IDs of private route tables"
   value       = ["${aws_route_table.route_table_private.*.id}"]
 }
+
+output "vpn_gateway_ids" {
+  description = "List of IDs of VPN gateways"
+  value       = ["${aws_vpn_gateway.vpn.*.id}"]
+}


### PR DESCRIPTION
Necessary for exposing the VPN Gateways as outputs for creating `aws_vpn_gateway_route_propagation` resources.